### PR TITLE
Set Render Setting to Compatibility

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -79,3 +79,7 @@ Global="*res://global.gd"
 window/size/viewport_width=1280
 window/size/viewport_height=540
 window/subwindows/embed_subwindows=false
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
With this change in setting, users can edit this project regardless of whether their GPU can run Vulcan.

Resolves #8.

Ideally, this would be carried over to the exported project.