### PR TITLE
Add support for macOS and Linux (and update to Godot 4.1.1)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "addons/GDScriptAudioImport"]
+	path = addons/GDScriptAudioImport
+	url = https://github.com/towai/GDScriptAudioImport.git

--- a/Chart.gd
+++ b/Chart.gd
@@ -230,6 +230,9 @@ func _draw():
 
 
 func _gui_input(event):
+	if event is InputEventPanGesture:
+		# Used for two finger scrolling on trackpads
+		_on_scroll_change()
 	event = event as InputEventMouseButton
 	if event == null || !event.pressed: return
 	if event.button_index == MOUSE_BUTTON_LEFT && !%PreviewController.is_playing:
@@ -247,7 +250,9 @@ func _gui_input(event):
 		
 		add_note(true, new_note_pos.x, current_subdiv, new_note_pos.y)
 	elif (event.button_index == MOUSE_BUTTON_WHEEL_DOWN) \
-			|| event.button_index == MOUSE_BUTTON_WHEEL_UP:
+			|| event.button_index == MOUSE_BUTTON_WHEEL_UP \
+			|| event.button_index == MOUSE_BUTTON_WHEEL_LEFT \
+			|| event.button_index == MOUSE_BUTTON_WHEEL_RIGHT:
 		_on_scroll_change()
 
 

--- a/Chart.gd
+++ b/Chart.gd
@@ -233,7 +233,7 @@ func _gui_input(event):
 	event = event as InputEventMouseButton
 	if event == null || !event.pressed: return
 	if event.button_index == MOUSE_BUTTON_LEFT && !%PreviewController.is_playing:
-		@warning_ignore(unassigned_variable)
+		@warning_ignore("unassigned_variable")
 		var new_note_pos : Vector2
 		
 		if settings.snap_time: new_note_pos.x = to_snapped(event.position).x

--- a/Note.gd
+++ b/Note.gd
@@ -196,7 +196,7 @@ func _process_drag():
 			length = new_end.x
 			pitch_delta = new_end.y
 		DRAG_INITIAL:
-			@warning_ignore(unassigned_variable)
+			@warning_ignore("unassigned_variable")
 			var new_pos : Vector2
 			
 			if Global.settings.snap_time: new_pos.x = chart.to_snapped(chart.get_local_mouse_position()).x
@@ -389,9 +389,6 @@ func _draw():
 	
 
 
-func grab_focus():
-	super()
-	queue_redraw()
 
 
 func _exit_tree():

--- a/Note.gd
+++ b/Note.gd
@@ -99,6 +99,8 @@ func _gui_input(event):
 		match key.keycode:
 			KEY_DELETE:
 				queue_free()
+			KEY_BACKSPACE:
+				queue_free()
 		return
 	
 	_on_handle_input(event,pitch_handle)

--- a/PreviewController.gd
+++ b/PreviewController.gd
@@ -24,7 +24,7 @@ func _do_preview():
 	
 	var bpm : float = chart.tmb.tempo
 	var time : float
-	@warning_ignore(unused_variable)
+	@warning_ignore("unused_variable")
 	var previous_time : float
 	var last_position : float
 	var initial_time : float = Time.get_ticks_msec() / 1000.0

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -3,6 +3,7 @@
 name="Windows Desktop"
 platform="Windows Desktop"
 runnable=true
+dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter="LICENSE, *.md"
@@ -12,25 +13,19 @@ encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false
 encrypt_directory=false
-script_export_mode=1
-script_encryption_key=""
 
 [preset.0.options]
 
 custom_template/debug=""
 custom_template/release=""
-debug/export_console_script=0
+debug/export_console_wrapper=1
 binary_format/embed_pck=true
 texture_format/bptc=false
 texture_format/s3tc=true
 texture_format/etc=false
 texture_format/etc2=false
-texture_format/no_bptc_fallbacks=true
 binary_format/architecture="x86_32"
 codesign/enable=false
-codesign/identity_type=0
-codesign/identity=""
-codesign/password=""
 codesign/timestamp=true
 codesign/timestamp_server_url=""
 codesign/digest_algorithm=1
@@ -38,6 +33,8 @@ codesign/description=""
 codesign/custom_options=PackedStringArray()
 application/modify_resources=true
 application/icon="res://icon.ico"
+application/console_wrapper_icon=""
+application/icon_interpolation=4
 application/file_version="0.9.0.0"
 application/product_version=""
 application/company_name="twi"
@@ -45,43 +42,70 @@ application/product_name="Trombone Charter"
 application/file_description=""
 application/copyright=""
 application/trademarks=""
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"
+debug/export_console_script=0
+texture_format/no_bptc_fallbacks=true
 
 [preset.1]
 
 name="macOS"
 platform="macOS"
 runnable=true
+dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
-export_path=""
+export_path="../Trombone Charter Mac.dmg"
 encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false
 encrypt_directory=false
-script_export_mode=1
-script_encryption_key=""
 
 [preset.1.options]
 
+export/distribution_type=1
 binary_format/architecture="universal"
 custom_template/debug=""
 custom_template/release=""
-debug/export_console_script=1
+debug/export_console_wrapper=1
 application/icon=""
+application/icon_interpolation=4
 application/bundle_identifier="com.tromb.charter"
 application/signature="twi"
-application/app_category="Games"
-application/short_version="1.0"
-application/version="1.0"
+application/app_category="Music-games"
+application/short_version="0.9.6"
+application/version="0.9.6"
 application/copyright=""
 application/copyright_localized={}
+application/min_macos_version="10.12"
 display/high_res=false
+xcode/platform_build="14C18"
+xcode/sdk_version="13.1"
+xcode/sdk_build="22C55"
+xcode/sdk_name="macosx13.1"
+xcode/xcode_version="1420"
+xcode/xcode_build="14C18"
 codesign/codesign=1
+codesign/installer_identity=""
+codesign/apple_team_id=""
 codesign/identity=""
-codesign/certificate_file=""
-codesign/certificate_password=""
 codesign/entitlements/custom_file=""
 codesign/entitlements/allow_jit_code_execution=false
 codesign/entitlements/allow_unsigned_executable_memory=false
@@ -107,11 +131,6 @@ codesign/entitlements/app_sandbox/files_movies=0
 codesign/entitlements/app_sandbox/helper_executables=[]
 codesign/custom_options=PackedStringArray()
 notarization/notarization=0
-notarization/apple_id_name=""
-notarization/apple_id_password=""
-notarization/apple_team_id=""
-notarization/api_uuid=""
-notarization/api_key=""
 privacy/microphone_usage_description=""
 privacy/microphone_usage_description_localized={}
 privacy/camera_usage_description=""
@@ -134,6 +153,19 @@ privacy/network_volumes_usage_description=""
 privacy/network_volumes_usage_description_localized={}
 privacy/removable_volumes_usage_description=""
 privacy/removable_volumes_usage_description_localized={}
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="#!/usr/bin/env bash
+unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
+open \"{temp_dir}/{exe_name}.app\" --args {cmd_args}"
+ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
+kill $(pgrep -x -f \"{temp_dir}/{exe_name}.app/Contents/MacOS/{exe_name} {cmd_args}\")
+rm -rf \"{temp_dir}\""
+debug/export_console_script=1
+notarization/apple_team_id=""
 texture_format/s3tc=true
 texture_format/etc=false
 texture_format/etc2=false
@@ -143,27 +175,39 @@ texture_format/etc2=false
 name="Linux/X11"
 platform="Linux/X11"
 runnable=true
+dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
-export_path="../trombonecharter_export/trombonecharter_x11.x86_64"
+export_path="../Trombone Charter Linux/trombonecharter_x11.x86_64"
 encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false
 encrypt_directory=false
-script_export_mode=1
-script_encryption_key=""
 
 [preset.2.options]
 
 custom_template/debug=""
 custom_template/release=""
-debug/export_console_script=0
+debug/export_console_wrapper=1
 binary_format/embed_pck=true
 texture_format/bptc=false
 texture_format/s3tc=true
 texture_format/etc=false
 texture_format/etc2=false
-texture_format/no_bptc_fallbacks=true
 binary_format/architecture="x86_64"
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="#!/usr/bin/env bash
+export DISPLAY=:0
+unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
+\"{temp_dir}/{exe_name}\" {cmd_args}"
+ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
+kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")
+rm -rf \"{temp_dir}\""
+debug/export_console_script=0
+texture_format/no_bptc_fallbacks=true

--- a/main.gd
+++ b/main.gd
@@ -147,7 +147,7 @@ func _on_save_chart_pressed():
 	else: show_popup($SaveDialog)
 
 func _on_save_dialog_file_selected(path:String):
-	if path[1] != ':':
+	if path[1] != ':' && OS.get_name() == "Windows":
 		print("driveless path %s" % path)
 		var drive : String
 		var saved_dir = cfg.get_value("Config","saved_dir")

--- a/main.tscn
+++ b/main.tscn
@@ -114,19 +114,14 @@ I'm in the Trombone Champ Modding Discord if you have issues or potential improv
 dialog_autowrap = true
 
 [node name="PianoRoll" type="HBoxContainer" parent="."]
-custom_minimum_size = Vector2i(360, 270)
+custom_minimum_size = Vector2(360, 270)
 layout_mode = 2
-offset_right = 1280.0
-offset_bottom = 390.0
 size_flags_vertical = 3
 theme_override_constants/separation = 0
 
 [node name="Piano" type="Control" parent="PianoRoll"]
-custom_minimum_size = Vector2i(144, 0)
+custom_minimum_size = Vector2(144, 0)
 layout_mode = 2
-anchors_preset = 0
-offset_right = 144.0
-offset_bottom = 390.0
 mouse_filter = 1
 script = ExtResource("3_mh03t")
 
@@ -149,9 +144,6 @@ text = "> <"
 [node name="ChartView" type="ScrollContainer" parent="PianoRoll"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 144.0
-offset_right = 1280.0
-offset_bottom = 390.0
 size_flags_horizontal = 3
 horizontal_scroll_mode = 2
 vertical_scroll_mode = 0
@@ -159,11 +151,8 @@ script = ExtResource("4_rrlxc")
 
 [node name="Chart" type="Control" parent="PianoRoll/ChartView"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(300, 0)
+custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
-anchors_preset = 0
-offset_right = 300.0
-offset_bottom = 382.0
 size_flags_vertical = 3
 script = ExtResource("5_yhpph")
 
@@ -221,17 +210,12 @@ script = ExtResource("10_fs4d4")
 [node name="Settings" type="PanelContainer" parent="."]
 unique_name_in_owner = true
 clip_contents = true
-custom_minimum_size = Vector2i(0, 150)
+custom_minimum_size = Vector2(0, 150)
 layout_mode = 2
-offset_top = 390.0
-offset_right = 1280.0
-offset_bottom = 540.0
 script = ExtResource("6_2cfeh")
 
 [node name="MarginC" type="MarginContainer" parent="Settings"]
 layout_mode = 2
-offset_right = 1280.0
-offset_bottom = 150.0
 theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
@@ -239,106 +223,67 @@ theme_override_constants/margin_bottom = 5
 
 [node name="HBoxC" type="HBoxContainer" parent="Settings/MarginC"]
 layout_mode = 2
-offset_left = 5.0
-offset_top = 5.0
-offset_right = 1275.0
-offset_bottom = 145.0
 
 [node name="Buttons" type="VBoxContainer" parent="Settings/MarginC/HBoxC"]
 layout_mode = 2
-offset_right = 110.0
-offset_bottom = 140.0
 
 [node name="ViewSwitcher" type="Button" parent="Settings/MarginC/HBoxC/Buttons"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(110, 0)
+custom_minimum_size = Vector2(110, 0)
 layout_mode = 2
-offset_right = 110.0
-offset_bottom = 28.0
 size_flags_vertical = 2
 text = "Editor Settings"
 
 [node name="LoadChart" type="Button" parent="Settings/MarginC/HBoxC/Buttons"]
 layout_mode = 2
-offset_top = 48.0
-offset_right = 110.0
-offset_bottom = 76.0
 text = "Load Chart"
 
 [node name="SaveChart" type="Button" parent="Settings/MarginC/HBoxC/Buttons"]
 layout_mode = 2
-offset_top = 80.0
-offset_right = 110.0
-offset_bottom = 108.0
 tooltip_text = "Hold Shift to bypass Save As dialog."
 text = "Save Chart"
 
 [node name="NewChart" type="Button" parent="Settings/MarginC/HBoxC/Buttons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 112.0
-offset_right = 110.0
-offset_bottom = 140.0
 text = "New Chart"
 
 [node name="ChartInfo" type="HBoxContainer" parent="Settings/MarginC/HBoxC"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-offset_left = 114.0
-offset_right = 1060.0
-offset_bottom = 140.0
 size_flags_horizontal = 3
 
 [node name="SongInfo" type="VFlowContainer" parent="Settings/MarginC/HBoxC/ChartInfo"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 478.0
-offset_bottom = 140.0
-grow_horizontal = 2
-grow_vertical = 2
 size_flags_horizontal = 6
 
 [node name="Title" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo" instance=ExtResource("6_hqpqp")]
 layout_mode = 2
-offset_left = 40.0
-offset_right = 234.0
 json_key = "name"
 field_name = "Title"
 
 [node name="ShortTitle" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo" instance=ExtResource("6_hqpqp")]
 layout_mode = 2
-offset_top = 52.0
-offset_right = 234.0
-offset_bottom = 88.0
 size_flags_vertical = 6
 json_key = "shortName"
 field_name = "Short Title"
 
 [node name="Author" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo" instance=ExtResource("6_hqpqp")]
 layout_mode = 2
-offset_left = 22.0
-offset_top = 104.0
-offset_right = 234.0
-offset_bottom = 140.0
 json_key = "author"
 field_name = "Author"
 
 [node name="Genre" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo" instance=ExtResource("6_hqpqp")]
 layout_mode = 2
-offset_left = 272.0
-offset_right = 478.0
 json_key = "genre"
 field_name = "Genre"
 
 [node name="Description" type="TextEdit" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(240, 0)
+custom_minimum_size = Vector2(240, 0)
 layout_mode = 2
-offset_left = 238.0
-offset_top = 40.0
-offset_right = 478.0
-offset_bottom = 140.0
 size_flags_vertical = 3
 placeholder_text = "Description"
 wrap_mode = 1
@@ -346,55 +291,32 @@ wrap_mode = 1
 [node name="SongInfo2" type="VFlowContainer" parent="Settings/MarginC/HBoxC/ChartInfo"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 482.0
-offset_right = 835.0
-offset_bottom = 140.0
 size_flags_horizontal = 2
 theme_override_constants/v_separation = 8
 
 [node name="Length" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo2" instance=ExtResource("7_6mp3m")]
 layout_mode = 2
-offset_left = 5.0
-offset_right = 181.0
-offset_bottom = 38.0
 json_key = "endpoint"
 field_name = "Length (beats)"
-min_value = 0
 max_value = 9999
 
 [node name="Tempo" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo2" instance=ExtResource("7_6mp3m")]
 layout_mode = 2
-offset_left = 55.0
-offset_top = 46.0
-offset_right = 181.0
-offset_bottom = 84.0
 json_key = "tempo"
 field_name = "Tempo"
-min_value = 0
 max_value = 999
 
 [node name="TimeSig" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo2" instance=ExtResource("7_6mp3m")]
 layout_mode = 2
-offset_top = 92.0
-offset_right = 181.0
-offset_bottom = 130.0
 json_key = "timesig"
 field_name = "Time Signature"
-min_value = 0
 max_value = 16
 
 [node name="Control" type="Control" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo2"]
 layout_mode = 2
-anchors_preset = 0
-offset_top = 138.0
-offset_right = 181.0
-offset_bottom = 138.0
 
 [node name="Year" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo2" instance=ExtResource("7_6mp3m")]
 layout_mode = 2
-offset_left = 243.0
-offset_right = 353.0
-offset_bottom = 41.0
 json_key = "year"
 field_name = "Year"
 min_value = -9999
@@ -402,100 +324,62 @@ max_value = 9999
 
 [node name="Diff" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo2" instance=ExtResource("7_6mp3m")]
 layout_mode = 2
-offset_left = 213.0
-offset_top = 49.0
-offset_right = 353.0
-offset_bottom = 90.0
 json_key = "difficulty"
 field_name = "Difficulty"
-min_value = 0
 max_value = 10
 
 [node name="NoteSpacing" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo2" instance=ExtResource("7_6mp3m")]
 layout_mode = 2
-offset_left = 185.0
-offset_top = 98.0
-offset_right = 353.0
-offset_bottom = 139.0
 json_key = "savednotespacing"
 field_name = "Note Spacing"
-min_value = 0
 max_value = 480
 
 [node name="ColorSettings" type="VBoxContainer" parent="Settings/MarginC/HBoxC/ChartInfo"]
 layout_mode = 2
-offset_left = 839.0
-offset_right = 946.0
-offset_bottom = 140.0
 
 [node name="Colors" type="HBoxContainer" parent="Settings/MarginC/HBoxC/ChartInfo/ColorSettings"]
 layout_mode = 2
-offset_right = 107.0
-offset_bottom = 32.0
 
 [node name="StartColor" type="ColorPickerButton" parent="Settings/MarginC/HBoxC/ChartInfo/ColorSettings/Colors"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(32, 32)
+custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
-offset_right = 32.0
-offset_bottom = 32.0
 color = Color(0.913725, 0.188235, 0.270588, 1)
 edit_alpha = false
 
 [node name="EndColor" type="ColorPickerButton" parent="Settings/MarginC/HBoxC/ChartInfo/ColorSettings/Colors"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(32, 32)
+custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
-offset_left = 36.0
-offset_right = 68.0
-offset_bottom = 32.0
 color = Color(1, 0.964706, 0.329412, 1)
 edit_alpha = false
 
 [node name="UseColors" type="CheckBox" parent="Settings/MarginC/HBoxC/ChartInfo/ColorSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 36.0
-offset_right = 107.0
-offset_bottom = 84.0
 text = "Use custom
 note colors"
 
 [node name="ColorPreview" type="Control" parent="Settings/MarginC/HBoxC/ChartInfo/ColorSettings"]
 layout_mode = 2
-anchors_preset = 0
-offset_top = 88.0
-offset_right = 107.0
-offset_bottom = 140.0
 size_flags_vertical = 3
 script = ExtResource("10_14v0o")
 
 [node name="EditSettings" type="VFlowContainer" parent="Settings/MarginC/HBoxC"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 114.0
-offset_right = 854.0
-offset_bottom = 140.0
 size_flags_horizontal = 3
 
 [node name="ZoomEntry" type="HBoxContainer" parent="Settings/MarginC/HBoxC/EditSettings"]
 layout_mode = 2
-offset_right = 232.0
-offset_bottom = 24.0
 
 [node name="Label" type="Label" parent="Settings/MarginC/HBoxC/EditSettings/ZoomEntry"]
 layout_mode = 2
-offset_right = 43.0
-offset_bottom = 23.0
 text = "Zoom:"
 
 [node name="ZoomLevel" type="HSlider" parent="Settings/MarginC/HBoxC/EditSettings/ZoomEntry"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 47.0
-offset_top = 4.0
-offset_right = 204.0
-offset_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
 tooltip_text = "1"
@@ -506,31 +390,20 @@ value = 1.0
 
 [node name="ZoomReset" type="Button" parent="Settings/MarginC/HBoxC/EditSettings/ZoomEntry"]
 layout_mode = 2
-offset_left = 208.0
-offset_right = 232.0
-offset_bottom = 24.0
 icon = ExtResource("14_8wa4s")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Settings/MarginC/HBoxC/EditSettings"]
 layout_mode = 2
-offset_top = 28.0
-offset_right = 232.0
-offset_bottom = 56.0
 
 [node name="TimeSnapChk" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 28.0
 button_pressed = true
 
 [node name="TimingSnap" type="SpinBox" parent="Settings/MarginC/HBoxC/EditSettings/HBoxContainer"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(204, 0)
+custom_minimum_size = Vector2(204, 0)
 layout_mode = 2
-offset_left = 28.0
-offset_right = 232.0
-offset_bottom = 28.0
 min_value = 1.0
 max_value = 12.0
 value = 4.0
@@ -540,24 +413,16 @@ suffix = "beats"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="Settings/MarginC/HBoxC/EditSettings"]
 layout_mode = 2
-offset_top = 60.0
-offset_right = 232.0
-offset_bottom = 88.0
 
 [node name="PitchSnapChk" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 28.0
 button_pressed = true
 
 [node name="PitchSnap" type="SpinBox" parent="Settings/MarginC/HBoxC/EditSettings/HBoxContainer2"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(204, 0)
+custom_minimum_size = Vector2(204, 0)
 layout_mode = 2
-offset_left = 28.0
-offset_right = 232.0
-offset_bottom = 28.0
 focus_mode = 2
 min_value = 1.0
 max_value = 12.0
@@ -569,46 +434,29 @@ suffix = "semitones"
 [node name="DrawMicrotones" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 92.0
-offset_right = 232.0
-offset_bottom = 120.0
 text = "Draw Microtones"
 
 [node name="DootToggle" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 236.0
-offset_right = 451.0
-offset_bottom = 28.0
 button_pressed = true
 text = "Doot on pitch change"
 
 [node name="PropagateChanges" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 236.0
-offset_top = 32.0
-offset_right = 451.0
-offset_bottom = 60.0
 button_pressed = true
 text = "Propagate changes in slides"
 
 [node name="ShowMouseTargets" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 236.0
-offset_top = 64.0
-offset_right = 451.0
-offset_bottom = 92.0
 text = "Outline mouse targets
 "
 
 [node name="TryAutoloadWAV" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 455.0
-offset_right = 740.0
-offset_bottom = 48.0
 button_pressed = true
 text = "On chart load / save:
 Try to load song.wav"
@@ -616,10 +464,6 @@ Try to load song.wav"
 [node name="ConvertOgg" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 455.0
-offset_top = 52.0
-offset_right = 740.0
-offset_bottom = 80.0
 size_flags_horizontal = 4
 tooltip_text = "Requires ffmpeg."
 button_pressed = true
@@ -628,24 +472,14 @@ alignment = 2
 
 [node name="Vol" type="HBoxContainer" parent="Settings/MarginC/HBoxC/EditSettings"]
 layout_mode = 2
-offset_left = 455.0
-offset_top = 84.0
-offset_right = 740.0
-offset_bottom = 108.0
 
 [node name="Label" type="Label" parent="Settings/MarginC/HBoxC/EditSettings/Vol"]
 layout_mode = 2
-offset_right = 25.0
-offset_bottom = 23.0
 text = "Vol."
 
 [node name="VolSlider" type="HSlider" parent="Settings/MarginC/HBoxC/EditSettings/Vol"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 29.0
-offset_top = 4.0
-offset_right = 257.0
-offset_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
 min_value = -12.0
@@ -656,18 +490,11 @@ ticks_on_borders = true
 
 [node name="VolReset" type="Button" parent="Settings/MarginC/HBoxC/EditSettings/Vol"]
 layout_mode = 2
-offset_left = 261.0
-offset_right = 285.0
-offset_bottom = 24.0
 icon = ExtResource("14_8wa4s")
 
 [node name="WAVLoadedLabel" type="Label" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 455.0
-offset_top = 117.0
-offset_right = 740.0
-offset_bottom = 140.0
 size_flags_vertical = 10
 text = "no song.wav loaded!"
 horizontal_alignment = 1
@@ -676,134 +503,83 @@ vertical_alignment = 2
 [node name="RefreshButton" type="Button" parent="Settings/MarginC/HBoxC/EditSettings"]
 visible = false
 layout_mode = 2
-offset_left = 455.0
-offset_top = 106.0
-offset_right = 622.0
-offset_bottom = 134.0
 size_flags_vertical = 10
 text = "Force note refresh"
 
 [node name="SectionSelection" type="VBoxContainer" parent="Settings/MarginC/HBoxC"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 858.0
-offset_right = 1041.0
-offset_bottom = 140.0
 size_flags_horizontal = 10
 
 [node name="HBox" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
 layout_mode = 2
-offset_right = 183.0
-offset_bottom = 28.0
 alignment = 2
 
 [node name="Label" type="Label" parent="Settings/MarginC/HBoxC/SectionSelection/HBox"]
 layout_mode = 2
-offset_left = 14.0
-offset_top = 2.0
-offset_right = 104.0
-offset_bottom = 25.0
 text = "Section Start:"
 
 [node name="SectionStart" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 108.0
-offset_right = 183.0
-offset_bottom = 28.0
 focus_mode = 2
 
 [node name="HBox2" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
 layout_mode = 2
-offset_top = 32.0
-offset_right = 183.0
-offset_bottom = 60.0
 alignment = 2
 
 [node name="Label" type="Label" parent="Settings/MarginC/HBoxC/SectionSelection/HBox2"]
 layout_mode = 2
-offset_top = 2.0
-offset_right = 104.0
-offset_bottom = 25.0
 text = "Section Length:"
 
 [node name="SectionLength" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox2"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 108.0
-offset_right = 183.0
-offset_bottom = 28.0
 focus_mode = 2
 min_value = 1.0
 value = 1.0
 
 [node name="HBox4" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
 layout_mode = 2
-offset_top = 71.0
-offset_right = 183.0
-offset_bottom = 101.0
 size_flags_vertical = 6
 alignment = 2
 
 [node name="MetroIcon" type="TextureRect" parent="Settings/MarginC/HBoxC/SectionSelection/HBox4"]
 layout_mode = 2
-offset_right = 30.0
-offset_bottom = 30.0
 texture = ExtResource("11_maqbd")
 stretch_mode = 2
 
 [node name="MetroChk" type="CheckBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox4"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 34.0
-offset_right = 117.0
-offset_bottom = 30.0
 size_flags_horizontal = 3
 
 [node name="PreviewButton" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/HBox4"]
 layout_mode = 2
-offset_left = 121.0
-offset_right = 183.0
-offset_bottom = 30.0
 text = "Preview"
 
 [node name="HBox3" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
 layout_mode = 2
-offset_top = 112.0
-offset_right = 183.0
-offset_bottom = 140.0
 alignment = 2
 
 [node name="CopyButton" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
 layout_mode = 2
-offset_left = 40.0
-offset_right = 104.0
-offset_bottom = 28.0
 tooltip_text = "Hold Shift to bypass confirmation"
 text = "Copy to:"
 
 [node name="CopyTarget" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 108.0
-offset_right = 183.0
-offset_bottom = 28.0
 focus_mode = 2
 
 [node name="LyricsTools" type="VBoxContainer" parent="Settings/MarginC/HBoxC"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 1045.0
-offset_right = 1229.0
-offset_bottom = 140.0
 size_flags_horizontal = 3
 
 [node name="ShowLyrics" type="CheckBox" parent="Settings/MarginC/HBoxC/LyricsTools"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 36.0
-offset_right = 184.0
-offset_bottom = 28.0
 size_flags_horizontal = 8
 size_flags_vertical = 2
 text = "Show lyrics editor"
@@ -811,21 +587,13 @@ text = "Show lyrics editor"
 [node name="AddLyric" type="Button" parent="Settings/MarginC/HBoxC/LyricsTools"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 56.0
-offset_top = 40.0
-offset_right = 184.0
-offset_bottom = 68.0
 size_flags_horizontal = 8
 text = "Add new lyric at..."
 
 [node name="LyricBar" type="SpinBox" parent="Settings/MarginC/HBoxC/LyricsTools"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(117, 0)
+custom_minimum_size = Vector2(117, 0)
 layout_mode = 2
-offset_left = 67.0
-offset_top = 72.0
-offset_right = 184.0
-offset_bottom = 100.0
 size_flags_horizontal = 8
 focus_mode = 2
 alignment = 2
@@ -834,18 +602,12 @@ prefix = "Beat"
 [node name="CopyLyrics" type="Button" parent="Settings/MarginC/HBoxC/LyricsTools"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 112.0
-offset_right = 133.0
-offset_bottom = 140.0
 size_flags_horizontal = 0
 size_flags_vertical = 10
 text = "Copy section lyrics"
 
 [node name="HelpButton" type="Button" parent="Settings/MarginC/HBoxC"]
 layout_mode = 2
-offset_left = 1233.0
-offset_right = 1270.0
-offset_bottom = 140.0
 size_flags_horizontal = 8
 tooltip_text = "Info & Usage"
 text = "   ?   "

--- a/project.godot
+++ b/project.godot
@@ -8,63 +8,11 @@
 
 config_version=5
 
-_global_script_classes=[{
-"base": "Node2D",
-"class": &"Alert",
-"language": &"GDScript",
-"path": "res://Alert.gd"
-}, {
-"base": "RefCounted",
-"class": &"AudioLoader",
-"language": &"GDScript",
-"path": "res://addons/GDScriptAudioImport/GDScriptAudioImport.gd"
-}, {
-"base": "Control",
-"class": &"Lyric",
-"language": &"GDScript",
-"path": "res://lyric.gd"
-}, {
-"base": "Control",
-"class": &"Note",
-"language": &"GDScript",
-"path": "res://Note.gd"
-}, {
-"base": "HBoxContainer",
-"class": &"NumField",
-"language": &"GDScript",
-"path": "res://num_field.gd"
-}, {
-"base": "PanelContainer",
-"class": &"Settings",
-"language": &"GDScript",
-"path": "res://Settings.gd"
-}, {
-"base": "Node",
-"class": &"TMBInfo",
-"language": &"GDScript",
-"path": "res://tmb_info.gd"
-}, {
-"base": "HBoxContainer",
-"class": &"TextField",
-"language": &"GDScript",
-"path": "res://text_field.gd"
-}]
-_global_script_class_icons={
-"Alert": "",
-"AudioLoader": "",
-"Lyric": "",
-"Note": "",
-"NumField": "",
-"Settings": "",
-"TMBInfo": "",
-"TextField": ""
-}
-
 [application]
 
 config/name="Trombone Charter"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.0", "Forward Plus")
+config/features=PackedStringArray("4.1", "Forward Plus")
 boot_splash/image="res://icon.png"
 boot_splash/fullsize=false
 config/icon="res://icon.svg"

--- a/project.godot
+++ b/project.godot
@@ -27,3 +27,4 @@ Global="*res://global.gd"
 window/size/viewport_width=1280
 window/size/viewport_height=540
 window/subwindows/embed_subwindows=false
+window/dpi/allow_hidpi=false


### PR DESCRIPTION
This PR updates a few things to get everthing running on Mac and Linux, along with some other small QOL changes and fixes:

 - Updated to Godot 4.1.1
 - Adds GDScriptAudioInport as a git submodule
 - Disables the hiDPI scaling option in Godot, leaving the host OS to handle scaling
   - This looks uglier as it's rendering at a lower internal resolution, but it's the simplest solution to ensure everything is at the correct scale on high DPI displays such as Retina MacBooks
   - I tried handling high DPI scaling properly, but I encountered issues with the popup windows. Something to revisit, maybe
   - This change has no impact on displays running at 100% scaling
 - Adds backspace as a key for note deletion
   - MacBooks don't have a Delete key on their keyboard lol
 - Fixes scrolling when tilting the mouse wheel left and right, or when using a trackpad

Done some quick testing on macOS, Linux and Windows and nothing seems to be broken yet. 👀

I'm not sure how well building will work on Windows, so I can provide prebuilt binaries for Mac and Linux if needed.