### PR TITLE
Add option to insert tap notes

### DIFF
--- a/main.tscn
+++ b/main.tscn
@@ -486,6 +486,11 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Draw Microtones"
 
+[node name="InsertTapNotes" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Insert tap notes"
+
 [node name="DootToggle" type="CheckBox" parent="Settings/MarginC/HBoxC/EditSettings"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -503,10 +508,6 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Outline mouse targets
 "
-
-[node name="spacer" type="Control" parent="Settings/MarginC/HBoxC/EditSettings"]
-custom_minimum_size = Vector2(0, 32)
-layout_mode = 2
 
 [node name="Label" type="Label" parent="Settings/MarginC/HBoxC/EditSettings"]
 layout_mode = 2
@@ -738,6 +739,7 @@ text = "toot toot lol"
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/EditSettings/TimeSnapping/TimingSnap" to="Settings" method="_on_timing_snap_value_changed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/EditSettings/PitchSnapping/PitchSnap" to="PianoRoll/ChartView" method="_on_pitch_snap_value_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/DrawMicrotones" to="PianoRoll/ChartView" method="queue_redraw"]
+[connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/InsertTapNotes" to="PianoRoll/ChartView" method="queue_redraw"]
 [connection signal="toggled" from="Settings/MarginC/HBoxC/EditSettings/DootToggle" to="PianoRoll/ChartView/Chart" method="_on_doot_toggle_toggled"]
 [connection signal="toggled" from="Settings/MarginC/HBoxC/EditSettings/PropagateChanges" to="PianoRoll/ChartView/Chart" method="_on_show_targets_toggled"]
 [connection signal="toggled" from="Settings/MarginC/HBoxC/EditSettings/ShowMouseTargets" to="PianoRoll/ChartView/Chart" method="_on_show_targets_toggled"]

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -246,14 +246,17 @@ func _gui_input(event):
 		if settings.snap_time: new_note_pos.x = to_snapped(event.position).x
 		else: new_note_pos.x = to_unsnapped(event.position).x
 		
+		# Current length of tap notes
+		var note_length = 0.0625 if settings.tap_notes else current_subdiv
+		
 		if new_note_pos.x == tmb.endpoint: new_note_pos.x -= (1.0 / settings.timing_snap)
-		if continuous_note_overlaps(new_note_pos.x, current_subdiv): return
+		if continuous_note_overlaps(new_note_pos.x, note_length): return
 		
 		if settings.snap_pitch: new_note_pos.y = to_snapped(event.position).y
 		else: new_note_pos.y = clamp(to_unsnapped(event.position).y,
 				Global.SEMITONE * -13, Global.SEMITONE * 13)
 		
-		add_note(true, new_note_pos.x, current_subdiv, new_note_pos.y)
+		add_note(true, new_note_pos.x, note_length, new_note_pos.y)
 	elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN \
 			|| event.button_index == MOUSE_BUTTON_WHEEL_UP \
 			|| event.button_index == MOUSE_BUTTON_WHEEL_LEFT \

--- a/settings.gd
+++ b/settings.gd
@@ -67,6 +67,9 @@ var timing_snap : int:
 var snap_time : bool:
 	get: return %TimeSnapChk.button_pressed
 
+var tap_notes : bool:
+	get: return %InsertTapNotes.button_pressed
+
 
 func _ready():
 	start_color = default_start_color


### PR DESCRIPTION
This adds an option to insert tap notes. Tap notes are any notes with a length of 0.0625 or less, so I just set the length to that value. Lower values make notes harder to hit and reward less score, so it's best to stick with this value.

I've also noticed a regression that breaks note placement unrelated to this commit if you'd like me to open an issue for it (I know you've been busy making some internal changes so I'm not sure if you're already aware of it).