### PR TITLE
Control improvements

### DIFF
--- a/copy_confirm.gd
+++ b/copy_confirm.gd
@@ -1,0 +1,28 @@
+extends AcceptDialog
+
+@onready var main : Node = get_parent()
+@onready var template = dialog_text
+var target: float
+var data: Dictionary
+
+func set_values(_target: float, _data: Dictionary):
+	target = _target
+	data = _data
+	var overwrite_notes = main.tmb.find_all_notes_in_section(target,data.length)
+	var to_overwrite = ("\nThis will overwrite %s notes!\n" % overwrite_notes.size()) if overwrite_notes else ""
+	dialog_text = template % [data.notes.size(), to_overwrite]
+
+func _on_copy_confirmed():
+	var notes = data.notes
+	if notes.is_empty():
+		print("copy section empy")
+		return
+	
+	main.tmb.clear_section(target,data.length)
+	for note in notes:
+		note[TMBInfo.NOTE_BAR] += target
+		main.tmb.notes.append(note)
+	main.tmb.notes.sort_custom(func(a,b): return a[TMBInfo.NOTE_BAR] < b[TMBInfo.NOTE_BAR])
+	main.emit_signal("chart_loaded")
+	%Alert.alert("Inserted %s notes from clipboard" % notes.size(), Vector2(%ChartView.global_position.x, 10),
+				Alert.LV_SUCCESS)

--- a/copy_confirm.gd
+++ b/copy_confirm.gd
@@ -24,5 +24,6 @@ func _on_copy_confirmed():
 		main.tmb.notes.append(note)
 	main.tmb.notes.sort_custom(func(a,b): return a[TMBInfo.NOTE_BAR] < b[TMBInfo.NOTE_BAR])
 	main.emit_signal("chart_loaded")
+	Global.settings.section_length = 0
 	%Alert.alert("Inserted %s notes from clipboard" % notes.size(), Vector2(%ChartView.global_position.x, 10),
 				Alert.LV_SUCCESS)

--- a/lyric.gd
+++ b/lyric.gd
@@ -95,6 +95,9 @@ func _on_line_edit_gui_input(event:InputEvent) -> void:
 						lyric.line_edit.grab_focus()
 						return
 				new_lyric = editor._add_lyric(new_bar, "")
-				if !new_lyric.is_in_view:
-					new_lyric.scroll_to_lyric()
 				new_lyric.line_edit.grab_focus()
+
+
+func _on_line_edit_focus_entered() -> void:
+	if !is_in_view:
+		scroll_to_lyric()

--- a/lyric.gd
+++ b/lyric.gd
@@ -13,6 +13,11 @@ var text : String:
 @onready var line_edit : LineEdit = $LineEdit
 @onready var editor = get_parent()
 @onready var chart = editor.chart
+@onready var chart_view = chart.get_parent()
+
+var is_in_view : bool:
+	get: return position.x + size.x >= chart.scroll_position \
+			&& position.x + line_edit.size.x <= chart.scroll_end
 
 func _ready():
 	line_edit.text = text
@@ -48,3 +53,42 @@ func _on_drag_handle_gui_input(event):
 	if event == null || event.button_index != MOUSE_BUTTON_LEFT || !event.pressed:
 		return
 	dragging = true
+
+func scroll_to_lyric(offset : float = 1.0):
+	offset = chart.bar_to_x(offset)
+	chart_view.set_h_scroll(int(position.x - offset))
+	chart.redraw_notes()
+	chart.queue_redraw()
+
+func _on_line_edit_gui_input(event:InputEvent) -> void:
+	if event is InputEventKey:
+		if not event.pressed:
+			return
+		var snap_value = 1.0 / Global.settings.timing_snap
+		match event.keycode:
+			KEY_UP:
+				bar += snap_value
+			KEY_DOWN:
+				bar -= snap_value
+			KEY_ENTER:
+				var new_lyric : Lyric
+				var new_bar : float
+				if editor.enter_mode == 0:
+					var notes = chart.get_children()
+					notes.sort_custom(func(a, b): return a.position.x < b.position.x)
+					var next_note : Note
+					for note in notes:
+						if not note is Note: continue
+						if note.bar > bar:
+							next_note = note
+							break
+					if next_note:
+						new_bar = next_note.bar
+				if !new_bar:
+					new_bar = snapped(bar + snap_value, snap_value)
+					if new_bar >= Global.working_tmb.endpoint:
+						return
+				new_lyric = editor._add_lyric(new_bar, "")
+				if !new_lyric.is_in_view:
+					new_lyric.scroll_to_lyric()
+				new_lyric.line_edit.grab_focus()

--- a/lyric.gd
+++ b/lyric.gd
@@ -88,6 +88,12 @@ func _on_line_edit_gui_input(event:InputEvent) -> void:
 					new_bar = snapped(bar + snap_value, snap_value)
 					if new_bar >= Global.working_tmb.endpoint:
 						return
+				for lyric in editor.get_children():
+					if lyric.bar == new_bar:
+						if !lyric.is_in_view:
+							lyric.scroll_to_lyric()
+						lyric.line_edit.grab_focus()
+						return
 				new_lyric = editor._add_lyric(new_bar, "")
 				if !new_lyric.is_in_view:
 					new_lyric.scroll_to_lyric()

--- a/lyric.tscn
+++ b/lyric.tscn
@@ -46,6 +46,7 @@ mouse_default_cursor_shape = 15
 texture_normal = ExtResource("3_65fow")
 
 [connection signal="pressed" from="DeleteButton" to="." method="_on_delete_button_pressed"]
+[connection signal="focus_entered" from="LineEdit" to="." method="_on_line_edit_focus_entered"]
 [connection signal="gui_input" from="LineEdit" to="." method="_on_line_edit_gui_input"]
 [connection signal="text_changed" from="LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="gui_input" from="DragHandle" to="." method="_on_drag_handle_gui_input"]

--- a/lyric.tscn
+++ b/lyric.tscn
@@ -44,5 +44,6 @@ mouse_default_cursor_shape = 15
 texture_normal = ExtResource("3_65fow")
 
 [connection signal="pressed" from="DeleteButton" to="." method="_on_delete_button_pressed"]
+[connection signal="gui_input" from="LineEdit" to="." method="_on_line_edit_gui_input"]
 [connection signal="text_changed" from="LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="gui_input" from="DragHandle" to="." method="_on_drag_handle_gui_input"]

--- a/lyric.tscn
+++ b/lyric.tscn
@@ -19,6 +19,7 @@ anchor_bottom = 1.0
 offset_top = -40.0
 offset_right = 40.0
 grow_vertical = 0
+focus_mode = 1
 icon = ExtResource("1_517y3")
 
 [node name="LineEdit" type="LineEdit" parent="."]
@@ -40,6 +41,7 @@ anchor_bottom = 0.75
 offset_left = -4.0
 offset_top = 64.0
 grow_vertical = 2
+focus_mode = 1
 mouse_default_cursor_shape = 15
 texture_normal = ExtResource("3_65fow")
 

--- a/main.gd
+++ b/main.gd
@@ -166,7 +166,7 @@ func try_cfg_save():
 
 
 func _on_copy_button_pressed():
-	if %CopyTarget.value + Global.settings.section_length > tmb.endpoint:
+	if %PlayheadPos.value + Global.settings.section_length > tmb.endpoint:
 		$Alert.alert("Can't copy -- would run past the chart endpoint!",
 				Vector2(%SectionSelection.position.x - 12, %Settings.position.y - 12),
 				Alert.LV_ERROR)
@@ -186,7 +186,7 @@ func _on_copy_confirmed():
 		print("copy section empy")
 		return
 	
-	var copy_target = Global.settings.section_target
+	var copy_target = Global.settings.playhead_pos
 	
 	tmb.clear_section(copy_target,length)
 	for note in notes:

--- a/main.gd
+++ b/main.gd
@@ -51,15 +51,21 @@ func _input(event):
 	if (		(get_viewport().gui_get_focus_owner() is TextEdit)
 			||  (get_viewport().gui_get_focus_owner() is LineEdit)):
 		return
+	if event.keycode == KEY_SHIFT:
+		if event.pressed:
+			%Chart.show_preview = true
+		else:
+			%Chart.show_preview = false
+		%Chart.queue_redraw()
 	if event.pressed && event.is_action_pressed("toggle_playback"):
 		%PreviewController._do_preview()
 	if event.is_action("select_mode") && !Input.is_key_pressed(KEY_CTRL):
 		%Chart.mouse_mode = %Chart.SELECT_MODE
-		$Alert.alert("Switched mouse to Select Mode", Vector2(%Chart.global_position.x, 10),
+		$Alert.alert("Switched mouse to Select Mode", Vector2(%ChartView.global_position.x, 10),
 				Alert.LV_SUCCESS)
 	if event.is_action("edit_mode") && !Input.is_key_pressed(KEY_CTRL):
 		%Chart.mouse_mode = %Chart.EDIT_MODE
-		$Alert.alert("Switched mouse to Edit Mode", Vector2(%Chart.global_position.x, 10),
+		$Alert.alert("Switched mouse to Edit Mode", Vector2(%ChartView.global_position.x, 10),
 				Alert.LV_SUCCESS)
 	#if event.pressed && event.keycode == KEY_C:
 		#print(%Chart.count_onscreen_notes()," notes being drawn")

--- a/main.gd
+++ b/main.gd
@@ -53,6 +53,14 @@ func _input(event):
 		return
 	if event.pressed && event.is_action_pressed("toggle_playback"):
 		%PreviewController._do_preview()
+	if event.is_action("select_mode") && !Input.is_key_pressed(KEY_CTRL):
+		%Chart.mouse_mode = %Chart.SELECT_MODE
+		$Alert.alert("Switched mouse to Select Mode", Vector2(%Chart.global_position.x, 10),
+				Alert.LV_SUCCESS)
+	if event.is_action("edit_mode") && !Input.is_key_pressed(KEY_CTRL):
+		%Chart.mouse_mode = %Chart.EDIT_MODE
+		$Alert.alert("Switched mouse to Edit Mode", Vector2(%Chart.global_position.x, 10),
+				Alert.LV_SUCCESS)
 	#if event.pressed && event.keycode == KEY_C:
 		#print(%Chart.count_onscreen_notes()," notes being drawn")
 	#if event.pressed && event.keycode == KEY_I:

--- a/main.tscn
+++ b/main.tscn
@@ -387,7 +387,8 @@ wrap_mode = 1
 
 [node name="TootTallyUpload" type="Button" parent="Settings/MarginC/HBoxC/ChartInfo/SongInfo"]
 layout_mode = 2
-text = "Upload to TootTally"
+tooltip_text = "Uploads the chart to TootTally's Difficulty Calculator, which provides a rough estimate for its difficulty along with some checks to TootTally's rating criteria."
+text = "Calculate Difficulty via TootTally"
 script = ExtResource("7_h0pqp")
 
 [node name="SongInfo2" type="VFlowContainer" parent="Settings/MarginC/HBoxC/ChartInfo"]
@@ -756,10 +757,34 @@ size_flags_horizontal = 8
 size_flags_vertical = 2
 text = "Show lyrics editor"
 
+[node name="Label3" type="Label" parent="Settings/MarginC/HBoxC/LyricsTools"]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+size_flags_horizontal = 8
+tooltip_text = "Controls what the enter key does when writing lyrics.
+
+Next Note will insert a new lyric at the next nearest note.
+
+Next Bar will instert a new lyric at the next bar."
+mouse_filter = 1
+text = "Enter key mode:"
+
+[node name="EnterKeyMode" type="OptionButton" parent="Settings/MarginC/HBoxC/LyricsTools"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 4
+item_count = 2
+selected = 0
+popup/item_0/text = "Next Note"
+popup/item_0/id = 0
+popup/item_1/text = "Next Bar"
+popup/item_1/id = 1
+
 [node name="CopyLyrics" type="Button" parent="Settings/MarginC/HBoxC/LyricsTools"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 0
+size_flags_horizontal = 8
 size_flags_vertical = 10
 text = "Copy section lyrics"
 

--- a/main.tscn
+++ b/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=3 uid="uid://dqnjrk008ccpy"]
+[gd_scene load_steps=27 format=3 uid="uid://dqnjrk008ccpy"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_4hx5p"]
 [ext_resource type="Script" path="res://save_load.gd" id="2_37xub"]
@@ -13,6 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://bu6gxk0umr8do" path="res://number_field.tscn" id="7_6mp3m"]
 [ext_resource type="Script" path="res://toottally.gd" id="7_h0pqp"]
 [ext_resource type="FontFile" uid="uid://bednem37cigyi" path="res://fonts/SourceCodePro-Regular.ttf" id="7_jt8rs"]
+[ext_resource type="Script" path="res://copy_confirm.gd" id="7_m5n28"]
 [ext_resource type="Script" path="res://pianoroll/chart_view.gd" id="8_j823s"]
 [ext_resource type="Script" path="res://ffmpeg_instructions.gd" id="8_wmpcw"]
 [ext_resource type="Script" path="res://pianoroll/chart.gd" id="9_g46yt"]
@@ -82,10 +83,11 @@ title = "You Sure?"
 position = Vector2i(200, 200)
 size = Vector2i(234, 192)
 unresizable = true
-dialog_text = "Anything that's already there will be deleted.
-
+dialog_text = "Are you sure you want to paste %s notes?
+%s
 Notes with tails going into or out of the section might end up overlapping other notes."
 dialog_autowrap = true
+script = ExtResource("7_m5n28")
 
 [node name="LoadDialog" type="FileDialog" parent="."]
 unique_name_in_owner = true
@@ -734,11 +736,6 @@ text = "Preview"
 layout_mode = 2
 alignment = 2
 
-[node name="CopyButton" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
-layout_mode = 2
-tooltip_text = "Hold Shift to bypass confirmation"
-text = "Copy to:"
-
 [node name="PlayheadPos" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -813,7 +810,7 @@ text = "toot toot lol"
 
 [connection signal="chart_loaded" from="." to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_chart_loaded"]
 [connection signal="confirmed" from="NewChartConfirm" to="." method="_on_new_chart_confirmed"]
-[connection signal="confirmed" from="CopyConfirm" to="." method="_on_copy_confirmed"]
+[connection signal="confirmed" from="CopyConfirm" to="CopyConfirm" method="_on_copy_confirmed"]
 [connection signal="file_selected" from="LoadDialog" to="." method="_on_load_dialog_file_selected"]
 [connection signal="file_selected" from="SaveDialog" to="." method="_on_save_dialog_file_selected"]
 [connection signal="meta_clicked" from="Instructions/RichTextLabel" to="." method="_on_rich_text_label_meta_clicked"]
@@ -856,7 +853,6 @@ text = "toot toot lol"
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox/SectionStart" to="Settings" method="_on_section_start_value_changed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox/SectionLength" to="Settings" method="_on_section_length_value_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox4/PreviewButton" to="PreviewController" method="_do_preview"]
-[connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/CopyButton" to="." method="_on_copy_button_pressed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/PlayheadPos" to="Settings" method="_on_copy_target_value_changed"]
 [connection signal="toggled" from="Settings/MarginC/HBoxC/LyricsTools/ShowLyrics" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_show_lyrics_toggled"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/LyricsTools/CopyLyrics" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_copy_lyrics_pressed"]

--- a/main.tscn
+++ b/main.tscn
@@ -685,11 +685,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Section:"
 
-[node name="SectionToViewButton" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/HBox2"]
-layout_mode = 2
-tooltip_text = "Move the section to the current scroll position."
-text = " Get Over Here "
-
 [node name="HBox" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
 layout_mode = 2
 alignment = 2
@@ -749,11 +744,6 @@ layout_mode = 2
 focus_mode = 2
 step = 2.08165e-12
 
-[node name="CopyHereButton" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
-layout_mode = 2
-tooltip_text = "Move copy handle to within the current view."
-text = "Here"
-
 [node name="LyricsTools" type="VBoxContainer" parent="Settings/MarginC/HBoxC"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -765,34 +755,6 @@ layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 2
 text = "Show lyrics editor"
-
-[node name="AddLyric" type="Button" parent="Settings/MarginC/HBoxC/LyricsTools"]
-unique_name_in_owner = true
-visible = false
-layout_mode = 2
-size_flags_horizontal = 8
-disabled = true
-text = "Add new lyric at..."
-
-[node name="HBoxContainer" type="HBoxContainer" parent="Settings/MarginC/HBoxC/LyricsTools"]
-visible = false
-layout_mode = 2
-size_flags_horizontal = 8
-
-[node name="LyricHereButton" type="Button" parent="Settings/MarginC/HBoxC/LyricsTools/HBoxContainer"]
-layout_mode = 2
-tooltip_text = "Move lyric handle to within the current view."
-text = "Here"
-
-[node name="LyricBar" type="SpinBox" parent="Settings/MarginC/HBoxC/LyricsTools/HBoxContainer"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(114, 0)
-layout_mode = 2
-size_flags_horizontal = 10
-focus_mode = 2
-alignment = 2
-editable = false
-prefix = "Beat"
 
 [node name="CopyLyrics" type="Button" parent="Settings/MarginC/HBoxC/LyricsTools"]
 unique_name_in_owner = true
@@ -866,16 +828,11 @@ text = "toot toot lol"
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/EditSettings/Vol2/TootVolSlider" to="Settings" method="_on_toot_volume_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/Vol2/VolReset" to="Settings" method="_on_toot_vol_reset_pressed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/RefreshButton" to="." method="_on_refresh_button_pressed"]
-[connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox2/SectionToViewButton" to="Settings" method="_on_section_to_view_button_pressed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox/SectionStart" to="Settings" method="_on_section_start_value_changed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox/SectionLength" to="Settings" method="_on_section_length_value_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox4/PreviewButton" to="PreviewController" method="_do_preview"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/CopyButton" to="." method="_on_copy_button_pressed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/PlayheadPos" to="Settings" method="_on_copy_target_value_changed"]
-[connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/CopyHereButton" to="Settings" method="_on_copy_here_button_pressed"]
 [connection signal="toggled" from="Settings/MarginC/HBoxC/LyricsTools/ShowLyrics" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_show_lyrics_toggled"]
-[connection signal="pressed" from="Settings/MarginC/HBoxC/LyricsTools/AddLyric" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_add_lyric_pressed"]
-[connection signal="pressed" from="Settings/MarginC/HBoxC/LyricsTools/HBoxContainer/LyricHereButton" to="Settings" method="_on_lyric_here_button_pressed"]
-[connection signal="value_changed" from="Settings/MarginC/HBoxC/LyricsTools/HBoxContainer/LyricBar" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_lyric_bar_value_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/LyricsTools/CopyLyrics" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_copy_lyrics_pressed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/HelpButton" to="." method="_on_help_button_pressed"]

--- a/main.tscn
+++ b/main.tscn
@@ -277,7 +277,7 @@ grow_vertical = 2
 mouse_default_cursor_shape = 2
 script = ExtResource("10_fs4d4")
 
-[node name="SectTargetHandle" type="Control" parent="PianoRoll/ChartView/Chart"]
+[node name="PlayheadHandle" type="Control" parent="PianoRoll/ChartView/Chart"]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 9
@@ -721,7 +721,6 @@ text = "Length:"
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 2
-value = 1.0
 
 [node name="HBox4" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
 layout_mode = 2
@@ -754,11 +753,11 @@ layout_mode = 2
 tooltip_text = "Hold Shift to bypass confirmation"
 text = "Copy to:"
 
-[node name="CopyTarget" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
+[node name="PlayheadPos" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 2
-value = 2.0
+step = 2.08165e-12
 
 [node name="CopyHereButton" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
 layout_mode = 2
@@ -878,7 +877,7 @@ text = "toot toot lol"
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox/SectionLength" to="Settings" method="_on_section_length_value_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox4/PreviewButton" to="PreviewController" method="_do_preview"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/CopyButton" to="." method="_on_copy_button_pressed"]
-[connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/CopyTarget" to="Settings" method="_on_copy_target_value_changed"]
+[connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/PlayheadPos" to="Settings" method="_on_copy_target_value_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/CopyHereButton" to="Settings" method="_on_copy_here_button_pressed"]
 [connection signal="toggled" from="Settings/MarginC/HBoxC/LyricsTools/ShowLyrics" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_show_lyrics_toggled"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/LyricsTools/AddLyric" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_add_lyric_pressed"]

--- a/main.tscn
+++ b/main.tscn
@@ -34,9 +34,10 @@ border_width_right = 8
 border_color = Color(0.25098, 0.25098, 0.25098, 1)
 
 [node name="Main" type="VBoxContainer"]
-anchors_preset = 15
-anchor_right = 1.0
+anchors_preset = -1
+anchor_right = 1.011
 anchor_bottom = 1.0
+offset_right = -14.0801
 grow_horizontal = 2
 grow_vertical = 2
 theme = SubResource("Theme_eswg4")
@@ -720,7 +721,6 @@ text = "Length:"
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 2
-min_value = 1.0
 value = 1.0
 
 [node name="HBox4" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]

--- a/main.tscn
+++ b/main.tscn
@@ -129,11 +129,17 @@ text = "Click in the chart view to create a note. Click on the piano to hear pit
 
 Drag a note by its start to change the timing, its tail to change its pitch, and its end to change its length and/or turn it into a slide. Middle-click it to delete it. With \"propagate slide changes\" enabled, hold Alt when dragging to break a note away from its neighbor. Note too short to easily grab the pitch handle? Hold Shift to bring it to the front.
 
+You can hold Shift and click to move the playhead to where your mouse cursor is.
+
+You can press the [b]S[/b] key to enter Select Mode. In this mode you can click and drag to select a segment of the song to preview. You can also copy and paste the notes you've selected using the usual keyboard shortcuts. You can press [b]E[/b] to return to Edit Mode.
+
+In the Lyrics Editor, you can double click to insert a new lyric where your mouse cursor is, and you can hit the Return key to insert a new lyric at the next note by default.
+
 The \"Track Ref\" field should be unique to your chart; you can use the song's name, or include both the name and the artist. If someone else has charted the same song before then make sure it doesn't clash with the existing chart's [code]trackRef[/code]. It is also best practice to name your chart's folder the same as your [code]trackRef[/code].
 
 You can hold Shift when clicking Save Chart to bypass the \"Save As\" dialog.
 
-On chart load and save, Trombone Charter will try to load song.ogg from the chart's folder. If [code]song.ogg[/code] is not present then no backing track will play.
+On chart load and save, Trombone Charter will try to load [code]song.ogg[/code] from the chart's folder. If [code]song.ogg[/code] is not present then no backing track will play.
 
 You can pass in a [code].tmb[/code] by dragging it onto the executable, and it will automatically be loaded.
 
@@ -622,52 +628,6 @@ layout_mode = 2
 text = "Generating audio preview..."
 horizontal_alignment = 1
 
-[node name="Vol" type="HBoxContainer" parent="Settings/MarginC/HBoxC/EditSettings"]
-layout_mode = 2
-size_flags_vertical = 10
-
-[node name="Label" type="Label" parent="Settings/MarginC/HBoxC/EditSettings/Vol"]
-layout_mode = 2
-text = "Track 🔊"
-
-[node name="TrackVolSlider" type="HSlider" parent="Settings/MarginC/HBoxC/EditSettings/Vol"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 4
-min_value = -12.0
-max_value = 6.0
-step = 0.1
-tick_count = 7
-ticks_on_borders = true
-
-[node name="VolReset" type="Button" parent="Settings/MarginC/HBoxC/EditSettings/Vol"]
-layout_mode = 2
-icon = ExtResource("14_8wa4s")
-
-[node name="Vol2" type="HBoxContainer" parent="Settings/MarginC/HBoxC/EditSettings"]
-layout_mode = 2
-size_flags_vertical = 10
-
-[node name="Label" type="Label" parent="Settings/MarginC/HBoxC/EditSettings/Vol2"]
-layout_mode = 2
-text = "Toot 🔊 "
-
-[node name="TootVolSlider" type="HSlider" parent="Settings/MarginC/HBoxC/EditSettings/Vol2"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 4
-min_value = -12.0
-max_value = 6.0
-step = 0.1
-tick_count = 7
-ticks_on_borders = true
-
-[node name="VolReset" type="Button" parent="Settings/MarginC/HBoxC/EditSettings/Vol2"]
-layout_mode = 2
-icon = ExtResource("14_8wa4s")
-
 [node name="RefreshButton" type="Button" parent="Settings/MarginC/HBoxC/EditSettings"]
 visible = false
 layout_mode = 2
@@ -686,9 +646,10 @@ alignment = 2
 [node name="Label" type="Label" parent="Settings/MarginC/HBoxC/SectionSelection/HBox2"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "Section:"
+text = "Playback Controls:"
 
 [node name="HBox" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
+visible = false
 layout_mode = 2
 alignment = 2
 
@@ -728,19 +689,62 @@ size_flags_horizontal = 3
 
 [node name="PreviewButton" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/HBox4"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(120, 0)
+custom_minimum_size = Vector2(100, 2.08165e-12)
 layout_mode = 2
 text = "Preview"
 
-[node name="HBox3" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
-layout_mode = 2
-alignment = 2
-
-[node name="PlayheadPos" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox3"]
+[node name="PlayheadPos" type="SpinBox" parent="Settings/MarginC/HBoxC/SectionSelection/HBox4"]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Playhead Position"
 focus_mode = 2
 step = 2.08165e-12
+
+[node name="Vol" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
+layout_mode = 2
+size_flags_vertical = 10
+
+[node name="Label" type="Label" parent="Settings/MarginC/HBoxC/SectionSelection/Vol"]
+layout_mode = 2
+text = "Track 🔊"
+
+[node name="TrackVolSlider" type="HSlider" parent="Settings/MarginC/HBoxC/SectionSelection/Vol"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+min_value = -12.0
+max_value = 6.0
+step = 0.1
+tick_count = 7
+ticks_on_borders = true
+
+[node name="VolReset" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/Vol"]
+layout_mode = 2
+icon = ExtResource("14_8wa4s")
+
+[node name="Vol2" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
+layout_mode = 2
+size_flags_vertical = 10
+
+[node name="Label" type="Label" parent="Settings/MarginC/HBoxC/SectionSelection/Vol2"]
+layout_mode = 2
+text = "Toot 🔊 "
+
+[node name="TootVolSlider" type="HSlider" parent="Settings/MarginC/HBoxC/SectionSelection/Vol2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+min_value = -12.0
+max_value = 6.0
+step = 0.1
+tick_count = 7
+ticks_on_borders = true
+
+[node name="VolReset" type="Button" parent="Settings/MarginC/HBoxC/SectionSelection/Vol2"]
+layout_mode = 2
+icon = ExtResource("14_8wa4s")
 
 [node name="LyricsTools" type="VBoxContainer" parent="Settings/MarginC/HBoxC"]
 unique_name_in_owner = true
@@ -845,15 +849,15 @@ text = "toot toot lol"
 [connection signal="toggled" from="Settings/MarginC/HBoxC/EditSettings/HBox/HiResWave" to="PianoRoll/ChartView/Chart/WavePreview" method="_on_hi_res_wave_toggled"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/HBox/FFmpegHelp" to="." method="_on_ffmpeg_help_pressed"]
 [connection signal="item_selected" from="Settings/MarginC/HBoxC/EditSettings/PreviewType" to="PianoRoll/ChartView/Chart/WavePreview" method="_on_preview_type_item_selected"]
-[connection signal="value_changed" from="Settings/MarginC/HBoxC/EditSettings/Vol/TrackVolSlider" to="Settings" method="_on_preview_volume_changed"]
-[connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/Vol/VolReset" to="Settings" method="_on_preview_vol_reset_pressed"]
-[connection signal="value_changed" from="Settings/MarginC/HBoxC/EditSettings/Vol2/TootVolSlider" to="Settings" method="_on_toot_volume_changed"]
-[connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/Vol2/VolReset" to="Settings" method="_on_toot_vol_reset_pressed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/EditSettings/RefreshButton" to="." method="_on_refresh_button_pressed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox/SectionStart" to="Settings" method="_on_section_start_value_changed"]
 [connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox/SectionLength" to="Settings" method="_on_section_length_value_changed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/HBox4/PreviewButton" to="PreviewController" method="_do_preview"]
-[connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox3/PlayheadPos" to="Settings" method="_on_copy_target_value_changed"]
+[connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/HBox4/PlayheadPos" to="Settings" method="_on_copy_target_value_changed"]
+[connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/Vol/TrackVolSlider" to="Settings" method="_on_preview_volume_changed"]
+[connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/Vol/VolReset" to="Settings" method="_on_preview_vol_reset_pressed"]
+[connection signal="value_changed" from="Settings/MarginC/HBoxC/SectionSelection/Vol2/TootVolSlider" to="Settings" method="_on_toot_volume_changed"]
+[connection signal="pressed" from="Settings/MarginC/HBoxC/SectionSelection/Vol2/VolReset" to="Settings" method="_on_toot_vol_reset_pressed"]
 [connection signal="toggled" from="Settings/MarginC/HBoxC/LyricsTools/ShowLyrics" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_show_lyrics_toggled"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/LyricsTools/CopyLyrics" to="PianoRoll/ChartView/Chart/LyricsEditor" method="_on_copy_lyrics_pressed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/HelpButton" to="." method="_on_help_button_pressed"]

--- a/main.tscn
+++ b/main.tscn
@@ -277,16 +277,6 @@ grow_vertical = 2
 mouse_default_cursor_shape = 2
 script = ExtResource("10_fs4d4")
 
-[node name="PlayheadHandle" type="Control" parent="PianoRoll/ChartView/Chart"]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 9
-anchor_bottom = 1.0
-offset_right = 6.0
-grow_vertical = 2
-mouse_default_cursor_shape = 2
-script = ExtResource("10_fs4d4")
-
 [node name="LyricsEditor" type="Control" parent="PianoRoll/ChartView/Chart"]
 unique_name_in_owner = true
 visible = false
@@ -298,7 +288,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("11_nxuar")
 
-[node name="AddLyricHandle" type="Control" parent="PianoRoll/ChartView/Chart/LyricsEditor"]
+[node name="PlayheadHandle" type="Control" parent="PianoRoll/ChartView/Chart"]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 9
@@ -778,12 +768,14 @@ text = "Show lyrics editor"
 
 [node name="AddLyric" type="Button" parent="Settings/MarginC/HBoxC/LyricsTools"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 size_flags_horizontal = 8
 disabled = true
 text = "Add new lyric at..."
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Settings/MarginC/HBoxC/LyricsTools"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 8
 

--- a/main.tscn
+++ b/main.tscn
@@ -845,6 +845,8 @@ text = "toot toot lol"
 [connection signal="meta_clicked" from="DiffCalc/PanelContainer/VBoxContainer/PanelContainer/CalcInfo" to="." method="_on_rich_text_label_meta_clicked"]
 [connection signal="pressed" from="DiffCalc/PanelContainer/VBoxContainer/Button" to="." method="_on_diff_ok_button_pressed"]
 [connection signal="pressed" from="PianoRoll/Piano/Button" to="PianoRoll/Piano" method="_on_button_pressed"]
+[connection signal="mouse_entered" from="PianoRoll/ChartView/Chart" to="PianoRoll/ChartView/Chart" method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="PianoRoll/ChartView/Chart" to="PianoRoll/ChartView/Chart" method="_on_mouse_exited"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/Buttons/ViewSwitcher" to="Settings" method="_on_view_switcher_pressed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/Buttons/LoadChart" to="." method="_on_load_chart_pressed"]
 [connection signal="pressed" from="Settings/MarginC/HBoxC/Buttons/SaveChart" to="." method="_on_save_chart_pressed"]

--- a/main.tscn
+++ b/main.tscn
@@ -699,6 +699,7 @@ layout_mode = 2
 tooltip_text = "Playhead Position"
 focus_mode = 2
 step = 2.08165e-12
+custom_arrow_step = 1.0
 
 [node name="Vol" type="HBoxContainer" parent="Settings/MarginC/HBoxC/SectionSelection"]
 layout_mode = 2

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -209,7 +209,7 @@ func update_note_array():
 
 func jump_to_note(note: int, use_tt: bool = false):
 	var count = 0
-	var children = %Chart.get_children()
+	var children = get_children()
 	if not use_tt:
 		children.sort_custom(func(a, b): return a.position.x < b.position.x)
 	for child in children:

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -249,6 +249,12 @@ func _draw():
 		if get_rect().has_point(mouse_pos):
 			draw_line(Vector2(mouse_pos.x,0), Vector2(mouse_pos.x,size.y),
 						Color.ORANGE_RED, 1 )
+		# no way to change the delay on a per-node basis, it seems
+		ProjectSettings.set_setting('gui/timers/tooltip_delay_sec', 0)
+		tooltip_text = ("%.4f" % %Chart.x_to_bar(mouse_pos.x)).rstrip('0.')
+	else:
+		ProjectSettings.set_setting('gui/timers/tooltip_delay_sec', 0.5)
+		tooltip_text = ""
 	if %PreviewController.is_playing:
 		if settings.section_length:
 			draw_line(Vector2(bar_to_x(%PreviewController.song_position),0),

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -103,7 +103,6 @@ func _do_tmb_update():
 	%SectionStart.max_value = tmb.endpoint
 	%SectionLength.max_value = max(1, tmb.endpoint - %SectionStart.value)
 	%PlayheadPos.max_value = tmb.endpoint
-	%LyricBar.max_value = tmb.endpoint - 1
 	%LyricsEditor._update_lyrics()
 	%Settings._update_handles()
 	for note in get_children():

--- a/pianoroll/chart.gd
+++ b/pianoroll/chart.gd
@@ -101,7 +101,7 @@ func _do_tmb_update():
 	custom_minimum_size.x = (tmb.endpoint + 1) * bar_spacing
 	%SectionStart.max_value = tmb.endpoint
 	%SectionLength.max_value = max(1, tmb.endpoint - %SectionStart.value)
-	%CopyTarget.max_value = tmb.endpoint - 1
+	%PlayheadPos.max_value = tmb.endpoint - 1
 	%LyricBar.max_value = tmb.endpoint - 1
 	%LyricsEditor._update_lyrics()
 	%Settings._update_handles()
@@ -239,14 +239,18 @@ func assign_tt_note_ids():
 func _draw():
 	var font : Font = ThemeDB.get_fallback_font()
 	if tmb == null: return
-	var section_rect = Rect2(bar_to_x(settings.section_start), 1,
-			bar_to_x(settings.section_length), size.y)
-	draw_rect(section_rect, Color(0.3, 0.9, 1.0, 0.1))
-	draw_rect(section_rect, Color.CORNFLOWER_BLUE, false, 3.0)
+	if settings.section_length:
+		var section_rect = Rect2(bar_to_x(settings.section_start), 1,
+				bar_to_x(settings.section_length), size.y)
+		draw_rect(section_rect, Color(0.3, 0.9, 1.0, 0.1))
+		draw_rect(section_rect, Color.CORNFLOWER_BLUE, false, 3.0)
 	if %PreviewController.is_playing:
-		draw_line(Vector2(bar_to_x(%PreviewController.song_position),0),
-				Vector2(bar_to_x(%PreviewController.song_position),size.y),
-				Color.CORNFLOWER_BLUE, 2 )
+		if settings.section_length:
+			draw_line(Vector2(bar_to_x(%PreviewController.song_position),0),
+					Vector2(bar_to_x(%PreviewController.song_position),size.y),
+					Color.CORNFLOWER_BLUE, 2 )
+		else:
+			settings.playhead_pos = %PreviewController.song_position
 	for i in tmb.endpoint + 1:
 		var line_x = i * bar_spacing
 		var next_line_x = (i + 1) * bar_spacing
@@ -272,8 +276,8 @@ func _draw():
 					str(i / tmb.timesig), HORIZONTAL_ALIGNMENT_LEFT, -1, 16)
 			draw_string(font, Vector2(i * bar_spacing, 0) + Vector2(8, 32),
 					str(i), HORIZONTAL_ALIGNMENT_LEFT, -1, 12)
-		draw_line(Vector2(bar_to_x(%CopyTarget.value), 0),
-				Vector2(bar_to_x(%CopyTarget.value), size.y),
+		draw_line(Vector2(bar_to_x(%PlayheadPos.value), 0),
+				Vector2(bar_to_x(%PlayheadPos.value), size.y),
 				Color.ORANGE_RED, 2.0)
 
 

--- a/pianoroll/lyrics_editor.gd
+++ b/pianoroll/lyrics_editor.gd
@@ -7,7 +7,6 @@ var _update_queued := false
 
 func _ready():
 	Global.tmb_updated.connect(_on_tmb_update)
-	%AddLyricHandle.double_clicked.connect(_add_lyric.bind(""))
 
 func _on_tmb_update(): _update_queued = true
 
@@ -32,6 +31,7 @@ func _add_lyric(bar:float,lyric:String):
 	new_lyric.text = lyric
 	new_lyric.bar = bar
 	add_child(new_lyric)
+	return new_lyric
 
 
 func _update_lyrics():
@@ -58,6 +58,7 @@ func _refresh_lyrics():
 
 func _on_show_lyrics_toggled(button_pressed):
 	move_to_front()
+	%PlayheadHandle.move_to_front()
 	set_visible(button_pressed)
 	%AddLyric.disabled = !button_pressed
 	%CopyLyrics.disabled = !button_pressed
@@ -67,15 +68,10 @@ func _on_show_lyrics_toggled(button_pressed):
 func _on_chart_loaded():
 	_refresh_lyrics()
 	move_to_front()
+	%PlayheadHandle.move_to_front()
 
 
 func _on_add_lyric_pressed(): _add_lyric(%LyricBar.value,"")
-
-func _on_lyric_bar_value_changed(value):
-	%LyricBar.value = value
-	%Settings._force_decimals(%LyricBar)
-	%AddLyricHandle.position.x = %Chart.bar_to_x(%LyricBar.value) - 3
-	queue_redraw()
 
 
 func _draw():
@@ -85,6 +81,15 @@ func _draw():
 			Color(0.7, 0.15, 1, 0.35), 8.0
 			)
 
+func _gui_input(event):
+	if Input.is_key_pressed(KEY_SHIFT):
+		%Chart.update_playhead(event)
+		return
+	if event is InputEventMouseButton and event.double_click:
+		var bar = %Chart.x_to_bar(event.position.x)
+		if %Settings.snap_time: bar = snapped(bar, chart.current_subdiv)
+		var new_lyric = _add_lyric(bar,"")
+		new_lyric.line_edit.grab_focus()
 
 func _on_copy_lyrics_pressed():
 	Global.working_tmb.lyrics = package_lyrics()

--- a/pianoroll/lyrics_editor.gd
+++ b/pianoroll/lyrics_editor.gd
@@ -60,9 +60,7 @@ func _on_show_lyrics_toggled(button_pressed):
 	move_to_front()
 	%PlayheadHandle.move_to_front()
 	set_visible(button_pressed)
-	%AddLyric.disabled = !button_pressed
 	%CopyLyrics.disabled = !button_pressed
-	%LyricBar.editable = button_pressed
 
 
 func _on_chart_loaded():
@@ -71,15 +69,8 @@ func _on_chart_loaded():
 	%PlayheadHandle.move_to_front()
 
 
-func _on_add_lyric_pressed(): _add_lyric(%LyricBar.value,"")
-
-
 func _draw():
 	draw_rect(Rect2(Vector2.ZERO,size), Color(0, 0, 0, 0.15))
-	var lyric_add_bar = chart.bar_to_x(%LyricBar.value)
-	draw_line(Vector2.RIGHT * lyric_add_bar, Vector2(lyric_add_bar,size.y),
-			Color(0.7, 0.15, 1, 0.35), 8.0
-			)
 
 func _gui_input(event):
 	if Input.is_key_pressed(KEY_SHIFT):

--- a/pianoroll/lyrics_editor.gd
+++ b/pianoroll/lyrics_editor.gd
@@ -3,6 +3,8 @@ extends Control
 
 var lyric_scn = preload("res://lyric.tscn")
 @onready var chart = %Chart
+@onready var enter_mode : int:
+	get: return %EnterKeyMode.selected
 var _update_queued := false
 
 func _ready():

--- a/pianoroll/lyrics_editor.gd
+++ b/pianoroll/lyrics_editor.gd
@@ -92,7 +92,7 @@ func _on_copy_lyrics_pressed():
 	var copied_lyrics := []
 	var section_start = Global.settings.section_start
 	var section_length = Global.settings.section_length
-	var copy_target = Global.settings.section_target
+	var copy_target = Global.settings.playhead_pos
 	
 	var copy_offset = copy_target - section_start
 	

--- a/preview_controller.gd
+++ b/preview_controller.gd
@@ -93,10 +93,7 @@ func _do_preview():
 	player.stop()
 
 	if !settings.section_length:
-		if settings.snap_time:
-			settings.playhead_pos = snapped(song_position, chart.current_subdiv)
-		else:
-			settings.playhead_pos = song_position
+		settings.playhead_pos = song_position
 	
 	song_position = -1.0
 	chart.queue_redraw()

--- a/preview_controller.gd
+++ b/preview_controller.gd
@@ -50,8 +50,10 @@ func _do_preview():
 		var elapsed_time = time - initial_time
 		
 		song_position = elapsed_time * (bpm / 60.0) + start_beat
-		if (settings.section_length && song_position > settings.section_start + settings.section_length) \
-				|| Input.is_key_pressed(KEY_ESCAPE): break
+		if (settings.section_length && song_position > settings.section_start + settings.section_length):
+			break
+		if song_position >= settings.length.value:
+			break
 		
 		if int(last_position) != int(song_position) && %MetroChk.button_pressed:
 			metronome.play()
@@ -90,8 +92,11 @@ func _do_preview():
 	StreamPlayer.stop()
 	player.stop()
 
-	if settings.snap_time && !settings.section_length:
-		settings.playhead_pos = snapped(song_position, chart.current_subdiv)
+	if !settings.section_length:
+		if settings.snap_time:
+			settings.playhead_pos = snapped(song_position, chart.current_subdiv)
+		else:
+			settings.playhead_pos = song_position
 	
 	song_position = -1.0
 	chart.queue_redraw()

--- a/preview_controller.gd
+++ b/preview_controller.gd
@@ -31,8 +31,11 @@ func _do_preview():
 	var previous_time : float
 	var last_position : float
 	var initial_time : float = Time.get_ticks_msec() / 1000.0
-	var startpoint_in_stream : float = Global.beat_to_time(settings.section_start)
-	var start_beat = settings.section_start
+	var startpoint_in_stream : float = Global.beat_to_time(settings.playhead_pos)
+	var start_beat : float = settings.playhead_pos
+	if settings.section_length:
+		startpoint_in_stream = Global.beat_to_time(settings.section_start)
+		start_beat = settings.section_start
 	var slide_start : float
 	var get_note_ons = func() -> Array[float]:
 		var arr : Array[float] = []
@@ -47,7 +50,7 @@ func _do_preview():
 		var elapsed_time = time - initial_time
 		
 		song_position = elapsed_time * (bpm / 60.0) + start_beat
-		if song_position > settings.section_start + settings.section_length \
+		if (settings.section_length && song_position > settings.section_start + settings.section_length) \
 				|| Input.is_key_pressed(KEY_ESCAPE): break
 		
 		if int(last_position) != int(song_position) && %MetroChk.button_pressed:
@@ -86,6 +89,9 @@ func _do_preview():
 	
 	StreamPlayer.stop()
 	player.stop()
+
+	if settings.snap_time && !settings.section_length:
+		settings.playhead_pos = snapped(song_position, chart.current_subdiv)
 	
 	song_position = -1.0
 	chart.queue_redraw()

--- a/project.godot
+++ b/project.godot
@@ -47,6 +47,16 @@ toggle_playback={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":32,"key_label":32,"unicode":32,"echo":false,"script":null)
 ]
 }
+edit_mode={
+"deadzone": 0.0,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":69,"unicode":0,"echo":false,"script":null)
+]
+}
+select_mode={
+"deadzone": 0.0,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":83,"unicode":115,"echo":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/section_handle.gd
+++ b/section_handle.gd
@@ -14,7 +14,10 @@ func _ready():
 	bar_changed.connect(%Settings.section_handle_dragged)
 
 func _on_mouse_entered():
-	Input.set_custom_mouse_cursor(grabby_hand, Input.CURSOR_POINTING_HAND, Vector2(9, 3))
+	Input.set_custom_mouse_cursor(
+		grabbing_hand if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) else grabby_hand,
+		Input.CURSOR_POINTING_HAND, Vector2(9, 3)
+	)
 func _on_mouse_exited():
 	if !Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 		Input.set_custom_mouse_cursor(null, Input.CURSOR_POINTING_HAND)
@@ -25,7 +28,7 @@ func update_pos(bar:float): position.x = %Chart.bar_to_x(bar) - 3
 
 func _gui_input(event):
 	var bar = chart.x_to_bar(event.position.x + position.x)
-	if %Settings.snap_time: bar = snapped(bar, chart.current_subdiv)
+	if %Settings.snap_time && self != %PlayheadHandle: bar = snapped(bar, chart.current_subdiv)
 	if event is InputEventMouseButton && event.button_index == MOUSE_BUTTON_LEFT:
 		var rect := Rect2(Vector2.ZERO, size)
 		Input.set_custom_mouse_cursor(grabbing_hand if event.pressed

--- a/settings.gd
+++ b/settings.gd
@@ -186,7 +186,7 @@ func section_handle_dragged(value:float,which:Node):
 
 func _on_section_start_value_changed(value):
 	section_start = value
-	%SectionLength.max_value = max(1,tmb.endpoint - value)
+	%SectionLength.max_value = tmb.endpoint - value
 	_force_decimals(%SectionStart)
 	%SectStartHandle.position.x = %Chart.bar_to_x(section_start) - SECT_HANDLE_RADIUS
 	%SectEndHandle.position.x = %Chart.bar_to_x(section_start + section_length) - SECT_HANDLE_RADIUS

--- a/settings.gd
+++ b/settings.gd
@@ -51,9 +51,9 @@ var section_start : float:
 var section_length : float:
 	get: return %SectionLength.value
 	set(with):  %SectionLength.value = with
-var section_target : float:
-	get: return %CopyTarget.value
-	set(with):  %CopyTarget.value = with
+var playhead_pos : float:
+	get: return %PlayheadPos.value
+	set(with):  %PlayheadPos.value = with
 @onready var sect_start_handle = %SectStartHandle
 
 
@@ -113,7 +113,7 @@ func _update_values():
 	year.value = tmb.year
 	diff.value = tmb.difficulty
 	notespc.value = tmb.savednotespacing
-	%CopyTarget.max_value = tmb.endpoint - 1
+	%PlayheadPos.max_value = tmb.endpoint - 1
 	_update_handles()
 	
 	if !use_custom_colors:
@@ -160,7 +160,7 @@ func _on_zoom_reset_pressed(): %ZoomLevel.value = 1
 func _update_handles():
 		%SectStartHandle.update_pos(section_start)
 		%SectEndHandle.update_pos(min(section_length + section_start,tmb.endpoint))
-		%SectTargetHandle.update_pos(section_target)
+		%PlayheadHandle.update_pos(playhead_pos)
 		%AddLyricHandle.update_pos(%LyricBar.value)
 
 func _force_decimals(box:SpinBox):
@@ -179,7 +179,7 @@ func section_handle_dragged(value:float,which:Node):
 		_on_section_start_value_changed(value)
 	elif which == %SectEndHandle: 
 		_on_section_length_value_changed(value - section_start)
-	elif which == %SectTargetHandle: 
+	elif which == %PlayheadHandle: 
 		_on_copy_target_value_changed(value)
 	if which == %AddLyricHandle:
 		%LyricsEditor._on_lyric_bar_value_changed(value)
@@ -199,9 +199,9 @@ func _on_section_length_value_changed(value):
 	%Chart.queue_redraw()
 
 func _on_copy_target_value_changed(value):
-	section_target = value
-	_force_decimals(%CopyTarget)
-	%SectTargetHandle.position.x = %Chart.bar_to_x(section_target) - SECT_HANDLE_RADIUS
+	playhead_pos = value
+	_force_decimals(%PlayheadPos)
+	%PlayheadHandle.position.x = %Chart.bar_to_x(playhead_pos) - SECT_HANDLE_RADIUS
 	%Chart.queue_redraw()
 
 func _on_section_to_view_button_pressed() -> void:
@@ -216,7 +216,7 @@ func _on_section_to_view_button_pressed() -> void:
 
 func _on_copy_here_button_pressed() -> void:
 	var bounds = %Chart.view_bounds
-	%SectTargetHandle.set_bar( bounds.center )
+	%PlayheadHandle.set_bar( bounds.center )
 
 func _on_lyric_here_button_pressed() -> void:
 	var bounds = %Chart.view_bounds
@@ -241,7 +241,6 @@ func _on_timing_snap_value_changed(value):
 	var snap = 1.0 / timing_snap
 	%SectionStart.step = snap
 	%SectionLength.step = snap
-	%CopyTarget.step = snap
 	%LyricBar.step = snap
 
 
@@ -251,10 +250,8 @@ func _on_time_snap_toggled(button_pressed):
 		true: 
 			%SectionStart.step	= snap
 			%SectionLength.step = snap
-			%CopyTarget.step	= snap
 			%LyricBar.step		= snap
 		false:
 			%SectionStart.step = 0.0001
 			%SectionLength.step = 0.0001
-			%CopyTarget.step = 0.0001
 			%LyricBar.step = 0.0001

--- a/settings.gd
+++ b/settings.gd
@@ -113,7 +113,7 @@ func _update_values():
 	year.value = tmb.year
 	diff.value = tmb.difficulty
 	notespc.value = tmb.savednotespacing
-	%PlayheadPos.max_value = tmb.endpoint - 1
+	%PlayheadPos.max_value = tmb.endpoint
 	_update_handles()
 	
 	if !use_custom_colors:

--- a/settings.gd
+++ b/settings.gd
@@ -163,11 +163,11 @@ func _update_handles():
 		%PlayheadHandle.update_pos(playhead_pos)
 
 func _force_decimals(box:SpinBox):
-	if box.value == int(box.value):
-		box.tooltip_text = str(box.value)
-		return
 	var lineedit = box.get_line_edit()
-	lineedit.text = ("%.4f" % box.value).rstrip('0')
+	if box.value == int(box.value):
+		lineedit.text = str(box.value)
+	else:
+		lineedit.text = ("%.4f" % box.value).rstrip('0')
 	box.tooltip_text = lineedit.text
 
 #region Sections

--- a/settings.gd
+++ b/settings.gd
@@ -201,24 +201,6 @@ func _on_copy_target_value_changed(value):
 	%PlayheadHandle.position.x = %Chart.bar_to_x(playhead_pos) - SECT_HANDLE_RADIUS
 	%Chart.queue_redraw()
 
-func _on_section_to_view_button_pressed() -> void:
-	var bounds = %Chart.view_bounds
-	var min_bar = ceil(  bounds.left )
-	var max_bar = floor( bounds.right )
-	if (section_start >= min_bar) && ( section_start <= max_bar): return
-	section_start = min_bar
-	# not totally sure we should do this part
-	var max_len = max_bar - min_bar
-	section_length = min(section_length,max_len)
-
-func _on_copy_here_button_pressed() -> void:
-	var bounds = %Chart.view_bounds
-	%PlayheadHandle.set_bar( bounds.center )
-
-# TODO: delete this
-# func _on_lyric_here_button_pressed() -> void:
-# 	var bounds = %Chart.view_bounds
-# 	%AddLyricHandle.set_bar( bounds.center )
 #endregion
 
 func _on_preview_vol_reset_pressed() -> void:

--- a/settings.gd
+++ b/settings.gd
@@ -161,7 +161,6 @@ func _update_handles():
 		%SectStartHandle.update_pos(section_start)
 		%SectEndHandle.update_pos(min(section_length + section_start,tmb.endpoint))
 		%PlayheadHandle.update_pos(playhead_pos)
-		%AddLyricHandle.update_pos(%LyricBar.value)
 
 func _force_decimals(box:SpinBox):
 	if box.value == int(box.value):
@@ -181,8 +180,6 @@ func section_handle_dragged(value:float,which:Node):
 		_on_section_length_value_changed(value - section_start)
 	elif which == %PlayheadHandle: 
 		_on_copy_target_value_changed(value)
-	if which == %AddLyricHandle:
-		%LyricsEditor._on_lyric_bar_value_changed(value)
 
 func _on_section_start_value_changed(value):
 	section_start = value
@@ -218,9 +215,10 @@ func _on_copy_here_button_pressed() -> void:
 	var bounds = %Chart.view_bounds
 	%PlayheadHandle.set_bar( bounds.center )
 
-func _on_lyric_here_button_pressed() -> void:
-	var bounds = %Chart.view_bounds
-	%AddLyricHandle.set_bar( bounds.center )
+# TODO: delete this
+# func _on_lyric_here_button_pressed() -> void:
+# 	var bounds = %Chart.view_bounds
+# 	%AddLyricHandle.set_bar( bounds.center )
 #endregion
 
 func _on_preview_vol_reset_pressed() -> void:
@@ -241,7 +239,6 @@ func _on_timing_snap_value_changed(value):
 	var snap = 1.0 / timing_snap
 	%SectionStart.step = snap
 	%SectionLength.step = snap
-	%LyricBar.step = snap
 
 
 func _on_time_snap_toggled(button_pressed):
@@ -250,8 +247,6 @@ func _on_time_snap_toggled(button_pressed):
 		true: 
 			%SectionStart.step	= snap
 			%SectionLength.step = snap
-			%LyricBar.step		= snap
 		false:
 			%SectionStart.step = 0.0001
 			%SectionLength.step = 0.0001
-			%LyricBar.step = 0.0001

--- a/settings.gd
+++ b/settings.gd
@@ -166,9 +166,10 @@ func _force_decimals(box:SpinBox):
 	var lineedit = box.get_line_edit()
 	if box.value == int(box.value):
 		lineedit.text = str(box.value)
+		box.tooltip_text = lineedit.text
 	else:
-		lineedit.text = ("%.4f" % box.value).rstrip('0')
-	box.tooltip_text = lineedit.text
+		box.tooltip_text = str(box.value)
+		lineedit.text = ("%.4f" % box.value).rstrip('0.')
 
 #region Sections
 const SECT_HANDLE_RADIUS = 3.0


### PR DESCRIPTION
This PR improves the controls of Trombone Charter in several areas

Select Mode
- You can press the S key to enter Select Mode, which lets you quickly highlight sections of the chart by clicking and dragging
- This means you no longer have to manually adjust number values or keep dragging your selection handle with you to highlight a different section of the chart
- Just clicking without dragging will deselect whatever was selected

Playback Changes
- The copy target handle has been repurposed into the playback head
- You no longer have to make a selection in order to preview the chart, and the playhead won't reset back to the start
- You can quickly move the playhead by holding the Shift key and clicking. When holding Shift a preview of the playhead's position will be shown
- You can still preview small segments of a chart when making a selection, which overrides the playhead.
  - This ensures that users can still use the old Section-based playback method if they need to

Lyric Changes
- You can now double click to insert lyrics at your mouse's position
- Hitting the Enter key will insert a new lyric at the next note, or at the next bar depending on user preference
- Hitting Tab or Shift + Tab will let you quickly switch between already placed lyrics
- Various improvements to focusing ensuring that the lyric you're editing will always be in view

Note Copying Changes
- You can now separately copy and paste notes using Ctrl + C and Ctrl + V, rather than just directly copying the notes of the current selection
- This uses the system clipboard, meaning that the data will persist between different charts or Charter instances
- Still uses the playback head for pasting
- Currently does not apply to the lyric editor

The UI has also been adjusted to remove any redundant controls.